### PR TITLE
Write AMSI_RESULT to console

### DIFF
--- a/AMSITrigger/Triggers.cs
+++ b/AMSITrigger/Triggers.cs
@@ -65,6 +65,7 @@ namespace AmsiTrigger
             result = scanBuffer(bigSample, amsiContext);
             if (result != AMSI_RESULT.AMSI_RESULT_DETECTED)
             {
+                Console.WriteLine(string.Format("[+] {0}", result));
                 return;
             }
 


### PR DESCRIPTION
This change writes the `AMSI_RESULT` to the console if it does not equal `AMSI_RESULT_DETECTED`.

```
C:\>AmsiTrigger.exe -i test.ps1
[+] AMSI_RESULT_NOT_DETECTED
```